### PR TITLE
Include sys/ioctl.h before calling ioctl()

### DIFF
--- a/src/editline.c
+++ b/src/editline.c
@@ -22,6 +22,7 @@
 #include <errno.h>
 #include <ctype.h>
 #include <signal.h>
+#include <sys/ioctl.h>
 
 #include "editline.h"
 


### PR DESCRIPTION
At least when building with Clang on OS X, there is an error on [line 1120 of editline.c](https://github.com/troglobit/editline/blob/master/src/editline.c#L1120) caused by using the `ioctl()` function without first declaring it by including its header (`<sys/ioctl.h>`). Adding this line makes the build complete without error.