### PR TITLE
add tty_flush to rl_forced_update_display

### DIFF
--- a/src/editline.c
+++ b/src/editline.c
@@ -1170,6 +1170,7 @@ void rl_clear_message(void)
 void rl_forced_update_display()
 {
     redisplay();
+    tty_flush();
 }
 
 char *readline(const char *prompt)


### PR DESCRIPTION
Forcing update should flush, otherwise weird stuff happen when writing to console asynchronously (cursor is moved, text is not displayed).