### PR TITLE
Fix sementation violation when displaying options

### DIFF
--- a/src/editline.c
+++ b/src/editline.c
@@ -176,7 +176,7 @@ static void tty_put(const char c)
 	return;
 
     Screen[ScreenCount] = c;
-    if (++ScreenCount > ScreenSize) {
+    if (++ScreenCount >= ScreenSize) {
         ScreenSize += SCREEN_INC;
         Screen = realloc(Screen, sizeof(char) * ScreenSize);
     }


### PR DESCRIPTION
Fix for #18 

When displaying a list of options, one extra byte of memory is used before the reallocation. This fix reallocates once all bytes of the array are used.