### PR TITLE
Avoid continuously duplicate commands in history

### DIFF
--- a/src/editline.c
+++ b/src/editline.c
@@ -1130,7 +1130,7 @@ static void hist_add(const char *p)
     char *s;
 
 #ifdef CONFIG_UNIQUE_HISTORY
-    if (H.Pos && strcmp(p, H.Lines[H.Pos - 1]) == 0)
+    if (H.Size && strcmp(p, H.Lines[H.Size - 1]) == 0)
         return;
 #endif
 


### PR DESCRIPTION
When adding a command to history, if CONFIG_UNIQUE_HISTORY is defined, always compare current command with the last entry in history.

Steps to reproduce the bug:
1. input a command A, press enter
2. input a command B, press enter
3. press up arrow, see B
4. press up arrow, see A
5. press down arrow, see B, press enter
6. press up arrow, see B,
7. press up arrow, still see B, this behavior is not expected.
