### PR TITLE
Fix issues about long commands

### DIFF
--- a/src/editline.c
+++ b/src/editline.c
@@ -187,27 +187,33 @@ static void tty_puts(const char *p)
         tty_put(*p++);
 }
 
-static void tty_show(unsigned char c)
+static int tty_show(unsigned char c)
 {
     if (c == DEL) {
         tty_put('^');
         tty_put('?');
+        return 2;
     } else if (ISCTL(c)) {
         tty_put('^');
         tty_put(UNCTL(c));
+        return 2;
     } else if (rl_meta_chars && ISMETA(c)) {
         tty_put('M');
         tty_put('-');
         tty_put(UNMETA(c));
+        return 3;
     } else {
         tty_put(c);
+        return 1;
     }
 }
 
-static void tty_string(char *p)
+static int tty_string(char *p)
 {
+    int n = 0;
     while (*p)
-        tty_show(*p++);
+        n += tty_show(*p++);
+    return n;
 }
 
 static void tty_push(int c)
@@ -784,9 +790,10 @@ static el_status_t delete_string(int count)
         p[0] = p[count];
     ceol();
     rl_end -= count;
-    tty_string(&rl_line_buffer[rl_point]);
+    i = tty_string(&rl_line_buffer[rl_point]);
+    tty_backn(i);
 
-    return CSmove;
+    return CSstay;
 }
 
 static el_status_t bk_char(void)

--- a/src/editline.c
+++ b/src/editline.c
@@ -771,7 +771,7 @@ static el_status_t delete_string(int count)
         }
         tty_backn(i);
         *p = '\0';
-        return CSmove;
+        return CSstay;
     }
 
     if (rl_point + count > rl_end && (count = rl_end - rl_point) <= 0)

--- a/src/editline.c
+++ b/src/editline.c
@@ -580,14 +580,27 @@ const char *el_prev_hist(void)
 
 static el_status_t do_insert_hist(const char *p)
 {
+    const char *pc;
+
     if (p == NULL)
         return el_ring_bell();
 
-    clear_line();
+    while (rl_point > 0)
+    {
+        --rl_point;
+        pc = &rl_line_buffer[rl_point];
+        tty_back();
+        if (ISCTL(*pc)) {
+            tty_back();
+        } else if (rl_meta_chars && ISMETA(*pc)) {
+            tty_back();
+            tty_back();
+        }
+    }
 
-    rl_point = 0;
-    reposition();
+    ceol();
     rl_end = 0;
+    rl_line_buffer[0] = '\0';
 
     return insert_string(p);
 }


### PR DESCRIPTION
This PR fixes a few bugs related to long commands.

Steps to reproduce the bugs:
1. type a long command, longer than screen/terminal width, so the line is wrapped, do not press enter yet;
2. press backspace, the first line will show twice (which is unexpected);
3. press left arrow several times, press backspace or delete key, unexpected behavior;
4. press left arrow several times, type anything, unexpected behavior;
5. press enter;
6. type a short command, press enter;
7. press up arrow, up arrow, down arrow, down arrow, unexpected behavior.

(can also try commands which are longer than 2 lines.)

The root cause of the bugs is the `tty_put('\r')` call in `reposition()`, which doesn't work well when the command is too long. Another issue in `reposition()` is the use of `rl_point` in the loop, I don't know whether I'll break anything if change it to `rl_end`, so in the end I decided to not run into `reposition()` (as well as `clear_line()`) at all. The new code is maybe less efficient.

This PR is now ready for review/merge.