### PR TITLE
Cleanup el_intr_pending in h_search_end()

### DIFF
--- a/src/editline.c
+++ b/src/editline.c
@@ -686,7 +686,7 @@ static el_status_t h_search_end(const char *p)
     rl_prompt = old_prompt;
     Searching = 0;
 
-    if (p == NULL && el_intr_pending > 0) {
+    if (el_intr_pending > 0) {
         el_intr_pending = 0;
         clear_line();
         return redisplay();


### PR DESCRIPTION
Possibly fixes #31: unexpected SIGINT when user pressed Ctrl+C when searching.