### PR TITLE
added fix for multiline representing as one line

### DIFF
--- a/src/editline.c
+++ b/src/editline.c
@@ -216,8 +216,10 @@ static void tty_string(char *p)
 
     while (*p) {
         tty_show(*p++);
-        if ((i++) % tty_cols == 0)
-            tty_put('\n');
+        if ((i++) % tty_cols == 0) {
+            tty_put(' ');
+            tty_put('\b');
+        }
     }
 }
 


### PR DESCRIPTION
There was a bug: multiline string were represented as new lines. This changes should fix it.