### PR TITLE
include <sys/select.h> in excallback

### DIFF
--- a/examples/excallback.c
+++ b/examples/excallback.c
@@ -39,6 +39,7 @@ Jeff
 
 #include <stdio.h>
 #include <sys/types.h>
+#include <sys/select.h>
 
 #ifdef HAVE_STDLIB_H
 #include <stdlib.h>


### PR DESCRIPTION
Fixes an build issue when cross-compiling for SerenityOS[1]

[1] https://github.com/SerenityOS/serenity

Also, it would be nice to add a flag in the configure script to skip building the examples, unless you're using them as some kind of test.