### PR TITLE
handle home and end keys in urxvt

### DIFF
--- a/src/editline.c
+++ b/src/editline.c
@@ -1061,6 +1061,8 @@ static el_status_t meta(void)
         case '4':  tty_get(); return end_line(); /* End */
         case '5':  tty_get(); return CSstay;     /* PgUp */
         case '6':  tty_get(); return CSstay;     /* PgDn */
+        case '7':  tty_get(); return beg_line(); /* Home (urxvt) */
+        case '8':  tty_get(); return end_line(); /* End (urxvt) */
         case 'A':  return h_prev();              /* Up */
         case 'B':  return h_next();              /* Down */
         case 'C':  return fd_char();             /* Left */


### PR DESCRIPTION
urxvt uses `\e[7~` and `\e[8~` for home and end, respectively. (where `\e` is ASCII `0x1b`) Currently these keys just type a `~` in an editline-based program running in urxvt, which is incredibly frustrating for me as I use these keys habitually. I've tested this, though not at all extensively, by rebuilding nix 2.4 to link against it and trying it in urxvt, xterm, and alacritty. I observed no problems.