### PR TITLE
Include stdio.h from editline.h

### DIFF
--- a/include/editline.h
+++ b/include/editline.h
@@ -21,6 +21,8 @@
 #ifndef EDITLINE_H_
 #define EDITLINE_H_
 
+#include <stdio.h>
+
 /* Handy macros when binding keys. */
 #define CTL(x)          ((x) & 0x1F)
 #define ISCTL(x)        ((x) && (x) < ' ')


### PR DESCRIPTION
Fixes `#include <editline.h>` without first including `<stdio.h>`, which previously errored at the missing typedef for `FILE`.