### PR TITLE
Avoid naming a dir "aux"

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 AC_INIT(editline, 1.17.1, https://github.com/troglobit/editline/issues)
-AC_CONFIG_AUX_DIR(aux)
+AC_CONFIG_AUX_DIR(build-aux)
 AM_INIT_AUTOMAKE([1.11 foreign dist-xz])
 AM_SILENT_RULES([yes])
 


### PR DESCRIPTION
This is a reserved name on win32. This results in this warning in autoreconf:
```
configure.ac:2: warning: name 'aux' is reserved on W32 and DOS platforms
```

I'm not sure if this lib actually works on windows, but the change is harmless regardless.