### PR TITLE
Rename man file to avoid collision with libedit

### DIFF
--- a/man/Makefile.am
+++ b/man/Makefile.am
@@ -1,3 +1,3 @@
 AUTOMAKE_OPTIONS = foreign
 
-dist_man_MANS = editline.3
+dist_man_MANS = libeditline.3


### PR DESCRIPTION
Hello,

The man file "editline.3" has the same name as the one provided by libedit. I think it would be good to change the name to avoid any collision during the packaging phases on Linux distributions. (Currently on Exherbo, but I saw that Gentoo and Archlinux were also impacted, and surely all...).

I renamed it to libeditline.3, but a different name will do the job.