### PR TITLE
configure.ac: fix `autoconf-2.72` compatibility

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -68,23 +68,23 @@ AC_ARG_ENABLE([examples],
 #
 # Check what features have been enabled
 #
-AS_IF([test "x$enable_unique_history" != "xno"],
-   AC_DEFINE(CONFIG_UNIQUE_HISTORY, 1, [Define to skip duplicate lines in the scrollback history.]))
+AS_IF([test "x$enable_unique_history" != "xno"], [
+   AC_DEFINE(CONFIG_UNIQUE_HISTORY, 1, [Define to skip duplicate lines in the scrollback history.])])
 
-AS_IF([test "x$enable_terminal_bell" != "xno"],
-   AC_DEFINE(CONFIG_ANSI_ARROWS, 1, [Define to include ANSI arrow keys support.]))
+AS_IF([test "x$enable_terminal_bell" != "xno"], [
+   AC_DEFINE(CONFIG_ANSI_ARROWS, 1, [Define to include ANSI arrow keys support.])])
 
-AS_IF([test "x$enable_eof" != "xno"],
-   AC_DEFINE(CONFIG_EOF, 1, [Define to enable EOF (Ctrl-D) key.]))
+AS_IF([test "x$enable_eof" != "xno"], [
+   AC_DEFINE(CONFIG_EOF, 1, [Define to enable EOF (Ctrl-D) key.])])
 
-AS_IF([test "x$enable_sigint" != "xno"],
-   AC_DEFINE(CONFIG_SIGINT, 1, [Define to enable SIGINT (Ctrl-C) key.]))
+AS_IF([test "x$enable_sigint" != "xno"], [
+   AC_DEFINE(CONFIG_SIGINT, 1, [Define to enable SIGINT (Ctrl-C) key.])])
 
-AS_IF([test "x$enable_sigstop" = "xyes"],
-   AC_DEFINE(CONFIG_SIGSTOP, 1, [Define to enable SIGSTOP (Ctrl-Z) key.]))
+AS_IF([test "x$enable_sigstop" = "xyes"], [
+   AC_DEFINE(CONFIG_SIGSTOP, 1, [Define to enable SIGSTOP (Ctrl-Z) key.])])
 
-AS_IF([test "x$enable_terminal_bell" = "xyes"],
-   AC_DEFINE(CONFIG_TERMINAL_BELL, 1, [Define to enable terminal bell on completion.]))
+AS_IF([test "x$enable_terminal_bell" = "xyes"], [
+   AC_DEFINE(CONFIG_TERMINAL_BELL, 1, [Define to enable terminal bell on completion.])])
 
 AM_CONDITIONAL([ENABLE_EXAMPLES], [test "$enable_examples" = yes])
 

--- a/configure.ac
+++ b/configure.ac
@@ -89,7 +89,7 @@ AS_IF([test "x$enable_terminal_bell" = "xyes"],
 AM_CONDITIONAL([ENABLE_EXAMPLES], [test "$enable_examples" = yes])
 
 # Check for a termcap compatible library if enabled
-AS_IF([test "x$enable_termcap" = "xyes"],
+AS_IF([test "x$enable_termcap" = "xyes"], [
    AC_DEFINE(CONFIG_USE_TERMCAP, 1, [Define to use the termcap library for terminal size.])
    AC_CHECK_LIB(terminfo, tgetent, , [
       AC_CHECK_LIB(termcap, tgetent, , [
@@ -100,7 +100,7 @@ AS_IF([test "x$enable_termcap" = "xyes"],
                ])
             ])
          ])
-      ]))
+      ])])
 
 # Generate all files
 AC_OUTPUT


### PR DESCRIPTION
`autoconf-2.72` slightly changed `AS_IF`/`AC_CHECL_LIB` definitions and exposed the bug of missng quoting around the arguments:

    editline> ./configure: line 13944: syntax error near unexpected token `;;'
    editline> ./configure: line 13944: ` ;;'

The change adds quoting as suggested by https://savannah.gnu.org/support/index.php?110990