### PR TITLE
Respect default prompt

### DIFF
--- a/src/editline.c
+++ b/src/editline.c
@@ -1435,7 +1435,8 @@ static int el_prep(const char *prompt)
     if (!Screen)
         return -1;
 
-    rl_prompt = prompt ? prompt : NILSTR;
+    if (prompt)
+        rl_prompt = prompt;
     prompt_len = strlen(rl_prompt);
 
     if (el_no_echo) {


### PR DESCRIPTION
A prompt `"? "` is set in `rl_initialize`, but it is never seen, because this line was replacing it with `NILSTR`.