### PR TITLE
Add rl_attempted_completion_over global to header

### DIFF
--- a/include/editline.h
+++ b/include/editline.h
@@ -84,6 +84,7 @@ extern int         rl_point;
 extern int         rl_mark;
 extern int         rl_end;
 extern int         rl_inhibit_complete;
+extern int         rl_attempted_completion_over;
 extern char       *rl_line_buffer;
 extern const char *rl_readline_name;
 extern FILE       *rl_instream;  /* The stdio stream from which input is read. Defaults to stdin if NULL - Not supported yet! */


### PR DESCRIPTION
The related feature is implemented but the variable was absent from the header, which caused using code to fail compiling.