### PR TITLE
Fix function prototypes.

### DIFF
--- a/examples/fileman.c
+++ b/examples/fileman.c
@@ -62,8 +62,8 @@ struct cmd commands[] = {
 };
 
 /* Forward declarations. */
-char *stripwhite();
-struct cmd *find_command();
+char *stripwhite(char *string);
+struct cmd *find_command(char *name);
 
 /* ~/.fileman_history */
 char *fileman_history;

--- a/src/editline.c
+++ b/src/editline.c
@@ -1431,7 +1431,7 @@ void rl_clear_message(void)
     /* Nothing to do atm. */
 }
 
-void rl_forced_update_display()
+void rl_forced_update_display(void)
 {
     redisplay(0);
     tty_flush();


### PR DESCRIPTION
This allows it to compile on macOS 15.3.2 using the default command-line tools (clang-1600.0.26.6).